### PR TITLE
[ENH] Update testing_interface.js: click again sets to black

### DIFF
--- a/apps/js/testing_interface.js
+++ b/apps/js/testing_interface.js
@@ -55,7 +55,13 @@ function setUpEditionGridListeners(jqGrid) {
         }
         else if (mode == 'edit') {
             // Else: fill just this cell.
-            setCellSymbol(cell, symbol);
+            old_symbol = parseInt(cell.attr('symbol'));
+            if (symbol == old_symbol) {
+                setCellSymbol(cell, 0);
+            }
+            else {
+                setCellSymbol(cell, symbol);
+            }
         }
     });
 }


### PR DESCRIPTION
On the [arcprize](https://arcprize.org/play) webpage, in 'edit' mode: clicking on a cell that is is already set to the current color will reset the cell to black. This is a convenient feature for the ARC-AGI html viewer too. This PR adds it.